### PR TITLE
Large changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ Currently it captures the following information for all the pools mounted at the
 
 # Usage
 1. Install and place btrfs.read.py in location accessible by telgraf.   For example /etc/telegraf/btrfs.read.py
-2. Grant telegraf permission to sudo btrfs command without password by adding the following to /etc/sudoers
+2. Grant telegraf permission to sudo btrfs command without password by adding a line similar to the following to /etc/sudoers
 ```
 telegraf ALL=(root) NOPASSWD: /usr/local/bin/btrfs
 ```
+You can discover the proper btrfs location by issuing `command -v btrfs` on your system.
+
 3. Update /etc/telegraf/telegraf.conf to call the script
 ```
  [[inputs.exec]]

--- a/README.md
+++ b/README.md
@@ -18,19 +18,20 @@ Currently it captures the following information for all the pools mounted at the
 * GlobalReserve (total, used, free)
 
 ## $btrfs filesystem usage
-* Device_size
-* Device_allocated
-* Device_unallocated
-* Device_missing
-* Used
-* Free_(estimated)
-* Data_ratio
-* Metadata_ratio
-* Global_reserve
-* Data (Per Device)
-* Metadata (Per Device)
-* System (Per Device)
-* Unallocated (Per Device)
+* device_size
+* device_allocated
+* device_unallocated
+* device_missing
+* used
+* free_estimated
+* free_statfs (btrfs-progs >= 5.10)
+* data_ratio
+* metadata_ratio
+* global_reserve
+* data (Per Device)
+* metadata (Per Device)
+* system (Per Device)
+* unallocated (Per Device)
 
 ## $btrfs scrub status
 * time_taken

--- a/README.md
+++ b/README.md
@@ -51,6 +51,26 @@ Currently it captures the following information for all the pools mounted at the
 * corrected_errors
 * last_physical
 
+# Example output
+```
+btrfs_stat,pool=/,drive=/dev/mapper/luks-0ff56354-f5c9-45b2-852c-a456641e5722 write_io_errs=0,read_io_errs=0,flush_io_errs=0,corruption_errs=0,generation_errs=0
+btrfs_df,type=Data,raidType=single,pool=/ total=30073159680,used=27799445504,free=2273714176
+btrfs_df,type=System,raidType=single,pool=/ total=4194304,used=16384,free=4177920
+btrfs_df,type=Metadata,raidType=single,pool=/ total=2155872256,used=1173159936,free=982712320
+btrfs_df,type=GlobalReserve,raidType=single,pool=/ total=79544320,used=0,free=79544320
+btrfs_usage,pool=/ device_size=254339448832,device_allocated=32233226240,device_unallocated=222106222592,device_missing=0,used=28972621824,free_estimated=224379936768,free_statfs=224378888192,data_ratio=1.00,metadata_ratio=1.00,global_reserve=79544320,multiple_profiles=no
+btrfs_usage,pool=/,drive=/dev/mapper/luks-0ff56354-f5c9-45b2-852c-a456641e5722 Data=30073159680,Metadata=2155872256,System=4194304,Unallocated=222106222592
+btrfs_scrub,pool=/ data_extents_scrubbed=0,tree_extents_scrubbed=0,data_bytes_scrubbed=0,tree_bytes_scrubbed=0,read_errors=0,csum_errors=0,verify_errors=0,no_csum=0,csum_discards=0,super_errors=0,malloc_errors=0,uncorrectable_errors=0,unverified_errors=0,corrected_errors=0,last_physical=0
+btrfs_stat,pool=/home,drive=/dev/mapper/luks-0ff56354-f5c9-45b2-852c-a456641e5722 write_io_errs=0,read_io_errs=0,flush_io_errs=0,corruption_errs=0,generation_errs=0
+btrfs_df,type=Data,raidType=single,pool=/home total=30073159680,used=27799445504,free=2273714176
+btrfs_df,type=System,raidType=single,pool=/home total=4194304,used=16384,free=4177920
+btrfs_df,type=Metadata,raidType=single,pool=/home total=2155872256,used=1173159936,free=982712320
+btrfs_df,type=GlobalReserve,raidType=single,pool=/home total=79544320,used=0,free=79544320
+btrfs_usage,pool=/home device_size=254339448832,device_allocated=32233226240,device_unallocated=222106222592,device_missing=0,used=28972621824,free_estimated=224379936768,free_statfs=224378888192,data_ratio=1.00,metadata_ratio=1.00,global_reserve=79544320,multiple_profiles=no
+btrfs_usage,pool=/home,drive=/dev/mapper/luks-0ff56354-f5c9-45b2-852c-a456641e5722 Data=30073159680,Metadata=2155872256,System=4194304,Unallocated=222106222592
+btrfs_scrub,pool=/home data_extents_scrubbed=0,tree_extents_scrubbed=0,data_bytes_scrubbed=0,tree_bytes_scrubbed=0,read_errors=0,csum_errors=0,verify_errors=0,no_csum=0,csum_discards=0,super_errors=0,malloc_errors=0,uncorrectable_errors=0,unverified_errors=0,corrected_errors=0,last_physical=0
+```
+
 # Usage
 1. Install and place btrfs.read.py in location accessible by telgraf.   For example /etc/telegraf/btrfs.read.py
 2. Grant telegraf permission to sudo btrfs command without password by adding a line similar to the following to /etc/sudoers
@@ -63,7 +83,7 @@ You can discover the proper btrfs location by issuing `command -v btrfs` on your
 ```
  [[inputs.exec]]
    commands = [
-     "python /etc/telegraf/btrfs.read.py"
+     "python3 /etc/telegraf/btrfs.read.py"
    ]
    timeout = "5s"
    data_format = "influx"
@@ -72,8 +92,3 @@ You can discover the proper btrfs location by issuing `command -v btrfs` on your
 # Requirements
 * python3
 * btrfs-tools
-
-# Donation
-If you find this useful and you would like to support please the use option below.
-
-[![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=jason%2ep%2eclara%40gmail%2ecom&lc=CA&item_name=Jason%20Clara&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Currently it captures the following information for all the pools mounted at the
 1. Install and place btrfs.read.py in location accessible by telgraf.   For example /etc/telegraf/btrfs.read.py
 2. Grant telegraf permission to sudo btrfs command without password by adding a line similar to the following to /etc/sudoers
 ```
-telegraf ALL=(root) NOPASSWD: /usr/local/bin/btrfs
+telegraf  ALL=(root) NOPASSWD: /usr/bin/btrfs filesystem df *, /usr/bin/btrfs device stat *, /usr/bin/btrfs filesystem usage *
 ```
 You can discover the proper btrfs location by issuing `command -v btrfs` on your system.
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Python script that can be used to capture BTRFS information in telegraf
 Currently it captures the following information for all the pools mounted at the time of running
 
 ## $btrfs device stat
-* write_io_errs
-* read_io_errs
-* flush_io_errs
-* corruption_errs
-* generation_errs
+* write_io_errs (per device)
+* read_io_errs (per device)
+* flush_io_errs (per device)
+* corruption_errs (per device)
+* generation_errs (per device)
 
 ## $btrfs filesystem df
 * Data (total, used, free)
@@ -32,12 +32,29 @@ Currently it captures the following information for all the pools mounted at the
 * System (Per Device)
 * Unallocated (Per Device)
 
+## $btrfs scrub status
+* time_taken
+* data_extents_scrubbed
+* tree_extents_scrubbed
+* data_bytes_scrubbed
+* tree_bytes_scrubbed
+* read_errors
+* csum_errors
+* verify_errors
+* no_csum
+* csum_discards
+* super_errors
+* malloc_errors
+* uncorrectable_errors
+* unverified_errors
+* corrected_errors
+* last_physical
 
 # Usage
 1. Install and place btrfs.read.py in location accessible by telgraf.   For example /etc/telegraf/btrfs.read.py
 2. Grant telegraf permission to sudo btrfs command without password by adding a line similar to the following to /etc/sudoers
 ```
-telegraf  ALL=(root) NOPASSWD: /usr/bin/btrfs filesystem df *, /usr/bin/btrfs device stat *, /usr/bin/btrfs filesystem usage *
+telegraf ALL=(root) NOPASSWD: /usr/bin/btrfs filesystem df *, /usr/bin/btrfs device stat *, /usr/bin/btrfs filesystem usage *
 ```
 You can discover the proper btrfs location by issuing `command -v btrfs` on your system.
 
@@ -52,10 +69,10 @@ You can discover the proper btrfs location by issuing `command -v btrfs` on your
 ```
 
 # Requirements
-* python
+* python3
 * btrfs-tools
 
 # Donation
-If you find this usefull and you would like to support please the use option below.
+If you find this useful and you would like to support please the use option below.
 
 [![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=jason%2ep%2eclara%40gmail%2ecom&lc=CA&item_name=Jason%20Clara&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Currently it captures the following information for all the pools mounted at the
 1. Install and place btrfs.read.py in location accessible by telgraf.   For example /etc/telegraf/btrfs.read.py
 2. Grant telegraf permission to sudo btrfs command without password by adding a line similar to the following to /etc/sudoers
 ```
-telegraf ALL=(root) NOPASSWD: /usr/bin/btrfs filesystem df *, /usr/bin/btrfs device stat *, /usr/bin/btrfs filesystem usage *
+telegraf ALL=(root) NOPASSWD: /usr/bin/btrfs filesystem df *, /usr/bin/btrfs device stat *, /usr/bin/btrfs filesystem usage *, /usr/bin/btrfs scrub status *
 ```
 You can discover the proper btrfs location by issuing `command -v btrfs` on your system.
 

--- a/btrfs.read.py
+++ b/btrfs.read.py
@@ -147,7 +147,7 @@ def getFileSystemUsageMeasurements(pool, sudo="sudo", btrfs="btrfs"):
             # skip the "overall" section with a slice
             outputstr = "{} ".format(output)
             for j in measurementLines[1:]:
-                if any(k in j for k in ["Multiple_profiles"]):
+                if any(k in j for k in ["Multiple_profiles", "Multiple profiles"]):
                     continue
                 measurementLinesSection = j.split(":")
                 # separate lines to meet flake8 requirements

--- a/btrfs.read.py
+++ b/btrfs.read.py
@@ -40,17 +40,18 @@ def getFileSystemDFMeasurements(pool, sudo="sudo", btrfs="btrfs"):
         if not line:
             continue
         lineSections = line.replace(':', ',').split(',')
-        if len(lineSections) > 1:
-            metric = lineSections[0].strip()
-            raidType = lineSections[1].strip()
-            total = lineSections[2].strip()
-            used = lineSections[3].strip()
-            free = int(total.split('=')[1]) - int(used.split('=')[1])
-            output = "btrfs,command={},".format(btrfsType)
-            output += "type={},raidType={},pool={}".format(metric, raidType,
-                                                           pool)
-            print("{} total={},used={},free={}".format(output, total,
-                                                       used, free))
+        if len(lineSections) < 2:
+            continue
+        metric = lineSections[0].strip()
+        raidType = lineSections[1].strip()
+        total = lineSections[2].strip()
+        used = lineSections[3].strip()
+        free = int(total.split('=')[1]) - int(used.split('=')[1])
+        output = "btrfs,command={},".format(btrfsType)
+        output += "type={},raidType={},pool={}".format(metric, raidType,
+                                                       pool)
+        print("{} total={},used={},free={}".format(output, total,
+                                                   used, free))
 
 
 def getFileSystemUsageMeasurements(pool, sudo="sudo", btrfs="btrfs"):
@@ -81,17 +82,18 @@ def getFileSystemUsageMeasurements(pool, sudo="sudo", btrfs="btrfs"):
         else:
             btype = measurementLines[0].replace(':', ',').split(',')[0]
             for j in measurementLines[1:]:
-                if len(j) > 1:
-                    measurementLinesSection = j.strip().split('\t')
-                    drive = measurementLinesSection[0].strip()
-                    value = measurementLinesSection[1].strip()
-                    log.debug("Drive: {}, Type: {}, Value: {}".format(drive,
-                                                                      btype,
-                                                                      value))
-                    if drive in drives:
-                        drives[drive][btype] = value
-                    else:
-                        drives[drive] = {btype: value}
+                if len(j) < 2:
+                    continue
+                measurementLinesSection = j.strip().split('\t')
+                drive = measurementLinesSection[0].strip()
+                value = measurementLinesSection[1].strip()
+                log.debug("Drive: {}, Type: {}, Value: {}".format(drive,
+                                                                  btype,
+                                                                  value))
+                if drive in drives:
+                    drives[drive][btype] = value
+                else:
+                    drives[drive] = {btype: value}
     for drive, data in drives.items():
         outputstr = "{},drive={} ".format(output, drive)
         for k, v in data.items():
@@ -108,18 +110,19 @@ def getDeviceStatMeasurements(pool, sudo="sudo", btrfs="btrfs"):
     drives = {}
     for stat in statArray:
         a = stat.split()
-        if len(a) > 1:
-            b = a[0].split('.')
-            drive = b[0].replace("[", "").replace("]", "")
-            metric = b[1]
-            value = a[1]
-            log.debug("Drive: {}, Metric: {}, Value: {}".format(drive,
-                                                                metric,
-                                                                value))
-            if drive in drives:
-                drives[drive][metric] = value
-            else:
-                drives[drive] = {metric: value}
+        if len(a) < 2:
+            continue
+        b = a[0].split('.')
+        drive = b[0].replace("[", "").replace("]", "")
+        metric = b[1]
+        value = a[1]
+        log.debug("Drive: {}, Metric: {}, Value: {}".format(drive,
+                                                            metric,
+                                                            value))
+        if drive in drives:
+            drives[drive][metric] = value
+        else:
+            drives[drive] = {metric: value}
     for drive, data in drives.items():
         outputstr = "{},drive={} ".format(output, drive)
         for k, v in data.items():

--- a/btrfs.read.py
+++ b/btrfs.read.py
@@ -97,10 +97,8 @@ def getFileSystemDFMeasurements(pool, sudo="sudo", btrfs="btrfs"):
         lineSections = line.replace(":", ",").split(",")
         if len(lineSections) < 2:
             continue
-        metric = lineSections[0].strip()
-        raidType = lineSections[1].strip()
-        total = lineSections[2].strip()
-        used = lineSections[3].strip()
+        lineSections = [l.strip() for l in lineSections]
+        metric, raidType, total, used = lineSections
         free = int(total.split("=")[1]) - int(used.split("=")[1])
         output = "btrfs_df,type={},raidType={},pool={}".format(metric,
                                                                raidType,

--- a/btrfs.read.py
+++ b/btrfs.read.py
@@ -68,7 +68,7 @@ def getFileSystemUsageMeasurements(pool, sudo="sudo", btrfs="btrfs"):
         if "Overall:" in measurementLines[0]:
             # skip the "overall" section with a slice
             for j in measurementLines[1:]:
-                if "Multiple_profiles" in metric:
+                if "Multiple_profiles" in j:
                     continue
                 measurementLinesSection = j.split(':')
                 metric = measurementLinesSection[0].strip()

--- a/btrfs.read.py
+++ b/btrfs.read.py
@@ -33,7 +33,9 @@ def getPools(excludeList, find_path="findmnt"):
 
 def scrub_stats(pool, sudo="sudo", btrfs="btrfs"):
     """
+    # one of the following
     scrub status for b24cf3ce-6063-4c63-8141-8c080e6d9bf4
+    UUID:             25cc55b6-cb1b-4aa6-917b-d979c0567c1b
         # one of the following:
          no stats available
          scrub started at Sat Nov  7 21:24:20 2020, running for 00:00:25

--- a/btrfs.read.py
+++ b/btrfs.read.py
@@ -64,7 +64,8 @@ def scrub_stats(pool, sudo="sudo", btrfs="btrfs"):
     for line in commandString.communicate()[0].decode("utf-8").split("\n"):
         line = line.strip()
         if not line or any(line.startswith(s) for s in ["scrub status",
-                                                        "no stats"]):
+                                                        "no stats",
+                                                        "UUID"]):
             continue
         if line.startswith("scrub started"):
             running = running_match.search(line)

--- a/btrfs.read.py
+++ b/btrfs.read.py
@@ -112,10 +112,12 @@ def getFileSystemUsageMeasurements(pool, sudo="sudo", btrfs="btrfs"):
         Device unallocated:		      229633949696
         Device missing:		                 0
         Used:			       10759409664
-        Free (estimated):		      233004806144	(min: 233004806144)
+        Free (estimated):              4.40TiB      (min: 2.94TiB)
+        Free (statfs, df):             3.32TiB
         Data ratio:			              1.00
         Metadata ratio:		              1.00
         Global reserve:		          26869760	(used: 0)
+        Multiple profiles:              no
 
     Data,single: Size:13967032320, Used:10596175872
        /dev/md125	13967032320
@@ -143,13 +145,14 @@ def getFileSystemUsageMeasurements(pool, sudo="sudo", btrfs="btrfs"):
             # skip the "overall" section with a slice
             outputstr = "{} ".format(output)
             for j in measurementLines[1:]:
-                if any(k in j for k in ["Multiple_profiles", "statfs"]):
+                if any(k in j for k in ["Multiple_profiles"]):
                     continue
                 measurementLinesSection = j.split(":")
                 # separate lines to meet flake8 requirements
                 metric = measurementLinesSection[0].strip()
                 metric = metric.replace(" ", "_").lower()
-                metric = metric.replace("_(estimated)", "")
+                metric = metric.replace("_(estimated)", "estimated")
+                metric = metric.replace("_(statfs,_df)", "statfs")
                 value = measurementLinesSection[1].strip().split("\t")[0]
                 outputstr += "{}={},".format(metric, value)
             print(outputstr.strip(","))

--- a/btrfs.read.py
+++ b/btrfs.read.py
@@ -146,7 +146,7 @@ def getFileSystemUsageMeasurements(pool, sudo="sudo", btrfs="btrfs"):
             # skip the "overall" section with a slice
             outputstr = "{} ".format(output)
             for j in measurementLines[1:]:
-                if "Multiple_profiles" in j:
+                if any(k in j for k in ["Multiple_profiles", "statfs"]):
                     continue
                 measurementLinesSection = j.split(":")
                 metric = measurementLinesSection[0].strip()

--- a/btrfs.read.py
+++ b/btrfs.read.py
@@ -47,9 +47,8 @@ def getFileSystemDFMeasurements(pool, sudo="sudo", btrfs="btrfs"):
             used = lineSections[3].strip()
             free = int(total.split('=')[1]) - int(used.split('=')[1])
             output = "btrfs,command={},".format(btrfsType)
-            output += "type={},".format(metric)
-            output += "raidType={},".format(raidType)
-            output += "pool={}".format(pool)
+            output += "type={},raidType={},pool={}".format(metric, raidType,
+                                                           pool)
             print("{} total={},used={},free={}".format(output, total,
                                                        used, free))
 

--- a/btrfs.read.py
+++ b/btrfs.read.py
@@ -50,8 +50,8 @@ def getFileSystemDFMeasurements(pool, sudo="sudo", btrfs="btrfs"):
         output = "btrfs,command={},".format(btrfsType)
         output += "type={},raidType={},pool={}".format(metric, raidType,
                                                        pool)
-        print("{} total={},used={},free={}".format(output, total,
-                                                   used, free))
+        print("{} {},{},free={}".format(output, total,
+                                        used, free))
 
 
 def getFileSystemUsageMeasurements(pool, sudo="sudo", btrfs="btrfs"):

--- a/btrfs.read.py
+++ b/btrfs.read.py
@@ -195,7 +195,7 @@ def getFileSystemUsageMeasurements(pool, sudo="sudo", btrfs="btrfs"):
         measurementLines = section.split("\n")
         if "Overall:" in measurementLines[0]:
             # skip the "overall" section with a slice
-            outputstr += " "
+            outputstr = f"{output} "
             for j in measurementLines[1:]:
                 if any(k in j for k in ["Multiple_profiles", "Multiple profiles"]):
                     continue

--- a/btrfs.read.py
+++ b/btrfs.read.py
@@ -151,8 +151,8 @@ def getFileSystemUsageMeasurements(pool, sudo="sudo", btrfs="btrfs"):
                 # separate lines to meet flake8 requirements
                 metric = measurementLinesSection[0].strip()
                 metric = metric.replace(" ", "_").lower()
-                metric = metric.replace("_(estimated)", "estimated")
-                metric = metric.replace("_(statfs,_df)", "statfs")
+                metric = metric.replace("_(estimated)", "_estimated")
+                metric = metric.replace("_(statfs,_df)", "_statfs")
                 value = measurementLinesSection[1].strip().split("\t")[0]
                 outputstr += "{}={},".format(metric, value)
             print(outputstr.strip(","))

--- a/btrfs.read.py
+++ b/btrfs.read.py
@@ -228,8 +228,7 @@ if __name__ == "__main__":
     if args.debug:
         log.setLevel(logging.DEBUG)
     btrfs, findmnt, sudo = _find_binaries()
-    exclude = args.exclude_pools.split(",")
-    pools = getPools(args.exclude_pools, findmnt)
+    pools = getPools(args.exclude_pools.split(","), findmnt)
     log.debug(pools)
 
     for pool in pools:

--- a/btrfs.read.py
+++ b/btrfs.read.py
@@ -68,6 +68,8 @@ def getFileSystemUsageMeasurements(pool, sudo="sudo", btrfs="btrfs"):
         if "Overall:" in measurementLines[0]:
             # skip the "overall" section with a slice
             for j in measurementLines[1:]:
+                if "Multiple_profiles" in metric:
+                    continue
                 measurementLinesSection = j.split(':')
                 metric = measurementLinesSection[0].strip()
                 metric = metric.replace(' ', '_').lower()

--- a/example-input.conf
+++ b/example-input.conf
@@ -1,5 +1,0 @@
-[[inputs.exec]]
-  # assuming the file was installed at /opt/btrfs.read.py
-  commands = ["/opt/btrfs.read.py"]
-  data_format = "influx"
-

--- a/example-input.conf
+++ b/example-input.conf
@@ -1,0 +1,5 @@
+[[inputs.exec]]
+  # assuming the file was installed at /opt/btrfs.read.py
+  commands = ["/opt/btrfs.read.py"]
+  data_format = "influx"
+


### PR DESCRIPTION
1. Move to python3 (since python2 is considered un-supported).
2. Make a lot of the `.value` metrics actually show the proper metric
3. make better use of influx format to reduce printed lines (this improves telegraf's performance with larger amounts of data)
4. `flake8` passes
5. example input config file
6. more restrictive telegraf sudo commands (so we don't give the `telegraf` user the ability to delete/modify btrfs volumes)
7. patch in the other MR in your repo
8. add scrub stats (need to work on the matching to get start/running/end times)

Example new output:
```
btrfs_stat,pool=/,drive=/dev/md125 write_io_errs=0,read_io_errs=0,flush_io_errs=0,corruption_errs=0,generation_errs=0
btrfs_df,type=Data,raidType=single,pool=/ total=13967032320,used=10596356096,free=3370676224
btrfs_df,type=System,raidType=single,pool=/ total=33554432,used=16384,free=33538048
btrfs_df,type=Metadata,raidType=single,pool=/ total=2155872256,used=163217408,free=1992654848
btrfs_df,type=GlobalReserve,raidType=single,pool=/ total=26869760,used=0,free=26869760
btrfs_usage,pool=/ device_size=245823963136,device_allocated=16156459008,device_unallocated=229667504128,device_missing=0,used=10759589888,free=233038180352,data_ratio=1.00,metadata_ratio=1.00,global_reserve=26869760
btrfs_usage,pool=/,drive=/dev/md125 Data=13967032320,Metadata=2155872256,System=33554432,Unallocated=229667504128
btrfs_scrub,pool=/ data_extents_scrubbed=275641,tree_extents_scrubbed=9965,data_bytes_scrubbed=10596188160,tree_bytes_scrubbed=163266560,read_errors=0,csum_errors=0,verify_errors=0,no_csum=1958,csum_discards=0,super_errors=0,malloc_errors=0,uncorrectable_errors=0,unverified_errors=0,corrected_errors=0,last_physical=17235443712
btrfs_stat,pool=/data,drive=/dev/sda write_io_errs=0,read_io_errs=0,flush_io_errs=0,corruption_errs=0,generation_errs=0
btrfs_stat,pool=/data,drive=/dev/sdb write_io_errs=0,read_io_errs=0,flush_io_errs=0,corruption_errs=0,generation_errs=0
btrfs_stat,pool=/data,drive=/dev/sdc write_io_errs=0,read_io_errs=0,flush_io_errs=0,corruption_errs=0,generation_errs=0
btrfs_stat,pool=/data,drive=/dev/sdd write_io_errs=0,read_io_errs=0,flush_io_errs=0,corruption_errs=0,generation_errs=0
btrfs_df,type=Data,raidType=RAID1,pool=/data total=4169339502592,used=4132889722880,free=36449779712
btrfs_df,type=System,raidType=RAID1,pool=/data total=33554432,used=573440,free=32980992
btrfs_df,type=Metadata,raidType=RAID1,pool=/data total=7516192768,used=5457084416,free=2059108352
btrfs_df,type=GlobalReserve,raidType=single,pool=/data total=536870912,used=0,free=536870912
btrfs_usage,pool=/data device_size=32006252888064,device_allocated=8353778499584,device_unallocated=23652474388480,device_missing=0,used=8276694761472,free=11862686973952,data_ratio=2.00,metadata_ratio=2.00,global_reserve=536870912
btrfs_usage,pool=/data,drive=/dev/sda Data=2081985396736,Metadata=6442450944,Unallocated=5913135374336
btrfs_usage,pool=/data,drive=/dev/sdb Data=2083059138560,Metadata=5368709120,Unallocated=5913135374336
btrfs_usage,pool=/data,drive=/dev/sdc Data=2087354105856,Metadata=1073741824,System=33554432,Unallocated=5913101819904
btrfs_usage,pool=/data,drive=/dev/sdd Data=2086280364032,Metadata=2147483648,System=33554432,Unallocated=5913101819904
btrfs_scrub,pool=/data data_extents_scrubbed=127438186,tree_extents_scrubbed=666190,data_bytes_scrubbed=8265474105344,tree_bytes_scrubbed=10914856960,read_errors=0,csum_errors=0,verify_errors=0,no_csum=497792,csum_discards=0,super_errors=0,malloc_errors=0,uncorrectable_errors=0,unverified_errors=0,corrected_errors=0,last_physical=8394756849664
```